### PR TITLE
Upvote existing tags when adding, closes #85

### DIFF
--- a/components/content/TitleBar.vue
+++ b/components/content/TitleBar.vue
@@ -727,10 +727,10 @@ export default {
               tmp.splice(tmp.indexOf(this.current_resource.tags[t]),1)
           }
 
-          for(let t in this.current_resource.s_tags){
-            if(tmp.indexOf(this.current_resource.s_tags[t].tag) != -1)
-              tmp.splice(tmp.indexOf(this.current_resource.s_tags[t].tag),1)
-          }
+          // for(let t in this.current_resource.s_tags){
+          //   if(tmp.indexOf(this.current_resource.s_tags[t].tag) != -1)
+          //     tmp.splice(tmp.indexOf(this.current_resource.s_tags[t].tag),1)
+          // }
 
 
           this.tag_options = tmp
@@ -811,7 +811,15 @@ export default {
         // }
 
 
-        this.$emit('suggestion_sent', this.tags)
+          let s_tags_titles = this.current_resource.s_tags.map(t => t['tag'])
+          for (let tag of this.tags) {
+            if (s_tags_titles.includes(tag)) {
+              this.$emit('vote_s_tag_up',s_tags_titles.indexOf(tag))
+            }
+          }
+
+          this.tags = this.tags.filter(tag => s_tags_titles.indexOf((tag)) == -1)
+          this.$emit('suggestion_sent', this.tags)
       }
     },
     created(){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- This feature allows to choose already suggested tags when tagger menu is open, on submit those tags will be automatically upvoted while new tags will be sent to the server.

## Motivation and Context
User stories: 
- When I am tagging I do not check the existing tags but simply add all tags that apply.
- Upvoting cannot be done without a mouse, while adding can be done keyboard only.

It closes an Issue #85 


## Info
The feature works everywhere where TitleBar component is used.

## How has this been tested?
- Adding multiple already suggested tags
- Adding new tags only
- Adding already suggested tags and new tags in one submit

## Screenshots (if appropriate):
![Animation](https://user-images.githubusercontent.com/83120061/122758303-50143000-d2a1-11eb-94d4-41e549e45074.gif)

